### PR TITLE
Related posts

### DIFF
--- a/components/BlogPostCard.vue
+++ b/components/BlogPostCard.vue
@@ -2,7 +2,7 @@
   <NuxtLink :to="`/posts/${post.slug}`" class="block">
     <article class="rounded-lg p-6 border hover:bg-purple-200/50 border-gray-200 bg-gray-100/50 transition">
       <h2 class="mb-2 text-md text-black">{{ post.title }}</h2>
-      <p class="text-sm text-gray-600 mb-6">
+      <p class="text-sm text-gray-600 mb-6" v-if="variant !== 'small'">
         {{ post.description }}
       </p>
 
@@ -21,6 +21,10 @@ import { Post } from '../types/Post';
 
 interface Props {
   post: Post
+  variant: 'default' | 'small'
 }
-const props = defineProps<Props>()
+
+const props = withDefaults(defineProps<Props>(), {
+  variant: 'default'
+})
 </script>

--- a/components/ProjectDetails.vue
+++ b/components/ProjectDetails.vue
@@ -21,6 +21,8 @@
         {{ project.short_description }}
       </p>
 
+      <BlogPostCard v-if="relatedPost" variant="small" :post="relatedPost" class="mt-6" />
+
       <div class="mt-10 text-sm">
         <NuxtLink v-if="project.website_url" :to="project.website_url" class="block">
           <BaseButton class="w-full" variant="primary">
@@ -46,7 +48,13 @@
 
 <script setup lang="ts">
 import { XMarkIcon } from '@heroicons/vue/24/solid'
-import { ArrowTopRightOnSquareIcon  } from '@heroicons/vue/16/solid'
+import { ArrowTopRightOnSquareIcon } from '@heroicons/vue/16/solid'
 import { Project } from '../types/Projects';
-defineProps<{ project: Project }>();
+import { Post } from '../types/Post';
+const props = defineProps<{ project: Project }>();
+
+const relatedPost = ref<null | Post>(null);
+if (props.project.related_post) {
+  relatedPost.value = await queryContent().where({ slug: props.project.related_post }).findOne();
+}
 </script>

--- a/data/projects.ts
+++ b/data/projects.ts
@@ -7,7 +7,8 @@ export const projects: Project[] = [
     website_url: 'https://kalf.no',
     github_url: 'https://github.com/kasperjha/kalf.no',
     technologies: ['vanilla javascript', 'tailwindcss'],
-    project_palette: 'blue'
+    project_palette: 'blue',
+    related_post: 'Learning-SVG-animation-with-baby-cows',
   },
   {
     title: 'realtime-pointers',

--- a/types/Projects.ts
+++ b/types/Projects.ts
@@ -6,4 +6,5 @@ export interface Project {
   demo_url?: string,
   technologies: string[],
   project_palette: 'sapling' | 'blue' | 'eyez' | 'toxic' | 'earth'
+  related_post?: string
 }


### PR DESCRIPTION
This PR introduces the concept of related blogpost 
- A project can have a single related blogpost 
- This blogpost will be shown in the project details modal 
- To relate the two entities the blogpost slug is used as an identifier 
- The project definition now includes an optional related post attribute 